### PR TITLE
Add support for native ameba config file

### DIFF
--- a/spec/codacy-ameba/config_spec.cr
+++ b/spec/codacy-ameba/config_spec.cr
@@ -2,10 +2,9 @@ require "../spec_helper.cr"
 
 module Codacy::Ameba
   describe Config do
-    it "loads default config values" do
+    it "returns nil if there's no config file" do
       config = Config.load("./")
-      config.tools.should eq [] of Tool
-      config.files.should eq [] of String
+      config.should eq nil
     end
 
     it "loads config from the file" do

--- a/src/codacy-ameba/config.cr
+++ b/src/codacy-ameba/config.cr
@@ -29,10 +29,11 @@ module Codacy::Ameba
     )
 
     def self.load(base_dir, filename = ".codacy.json")
-      data = File.read("#{base_dir}/#{filename}")
+      path = "#{base_dir}/#{filename}"
+      data = File.read(path)
       Config.from_json(data)
     rescue
-      Config.from_json("{}")
+      nil
     end
   end
 end

--- a/src/codacy-ameba/runner.cr
+++ b/src/codacy-ameba/runner.cr
@@ -10,7 +10,7 @@ module Codacy::Ameba
 
       ameba_config = ::Ameba::Config.load("#{dir}/.ameba.yml", true)
 
-      if codacy_config.is_a?(Codacy::Ameba::Config)
+      if codacy_config
         configure_files(ameba_config, codacy_config.files)
         configure_rules(ameba_config, codacy_config.tools)
       else
@@ -35,7 +35,7 @@ module Codacy::Ameba
     private def configure_rules(config)
       config.rules.map! { |r|
         excluded = r.excluded
-        if excluded.is_a?(Array(String)) 
+        if excluded 
           r.excluded = excluded.map { |e| "#{dir}/#{e}" } 
         end
         r


### PR DESCRIPTION
According to the documentation of the [codacy-engine-scala-seed](https://github.com/codacy/codacy-engine-scala-seed) "If /.codacyrc does not exist or any of its contents (files or patterns) is not available, you should invoke the tool for all files from /src (files should be searched recursively for all folders in /src) and check them with **the tool's native configuration file, if it is supported and if it exists**. Otherwise, run the tool with the default patterns." 
This PR adds the missing part, the support for the tool's native configuration.